### PR TITLE
Populate database with some predefined chests

### DIFF
--- a/app/src/main/java/com/jezerm/pokepc/MainActivity.kt
+++ b/app/src/main/java/com/jezerm/pokepc/MainActivity.kt
@@ -18,15 +18,24 @@ import com.jezerm.pokepc.data.ItemDtoRoomDatabase
 import com.jezerm.pokepc.data.RoomRepository
 import com.jezerm.pokepc.navigation.AppNavHost
 import com.jezerm.pokepc.ui.theme.PokePCTheme
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     // Get the database
     val database by lazy { ItemDtoRoomDatabase.getDatabase(this) }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Initialize the Room repository based in the ItemDto DAO
         RoomRepository.init(database.itemDtoDao())
+
+        GlobalScope.launch(Dispatchers.IO) {
+            database.runInTransaction {}
+        }
 
         setContent {
             PokePCTheme {

--- a/app/src/main/java/com/jezerm/pokepc/data/ChestPopulate.kt
+++ b/app/src/main/java/com/jezerm/pokepc/data/ChestPopulate.kt
@@ -1,0 +1,19 @@
+package com.jezerm.pokepc.data
+
+import com.jezerm.pokepc.entities.Chest
+import com.jezerm.pokepc.entities.Item
+
+val chestOnePopulate = arrayOf(
+    ItemDto(Item.WHEAT, 3, 1, Chest.ChestType.ONE.value),
+    ItemDto(Item.SUGAR_CANE, 2, 3, Chest.ChestType.ONE.value),
+    ItemDto(Item.IRON, 8, 5, Chest.ChestType.ONE.value),
+)
+val chestTwoPopulate = arrayOf(
+    ItemDto(Item.SAND, 5, 2, Chest.ChestType.TWO.value),
+    ItemDto(Item.OBSIDIAN, 4, 4, Chest.ChestType.TWO.value),
+    ItemDto(Item.DIAMOND, 1, 5, Chest.ChestType.TWO.value),
+)
+val chestThreePopulate = arrayOf(
+    ItemDto(Item.WOOD, 8, 1, Chest.ChestType.THREE.value),
+    ItemDto(Item.DIAMOND, 1, 6, Chest.ChestType.THREE.value),
+)

--- a/app/src/main/java/com/jezerm/pokepc/data/ItemDtoRoomDatabase.kt
+++ b/app/src/main/java/com/jezerm/pokepc/data/ItemDtoRoomDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import java.util.concurrent.Executors
 
 @Database(entities = arrayOf(ItemDto::class), version = 1, exportSchema = false)
 abstract class ItemDtoRoomDatabase : RoomDatabase() {
@@ -19,12 +21,29 @@ abstract class ItemDtoRoomDatabase : RoomDatabase() {
         fun getDatabase(context: Context): ItemDtoRoomDatabase {
             // if the INSTANCE is not null, then return it,
             // if it is, then create the database
+
+            //context.deleteDatabase("RoomTest")
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     ItemDtoRoomDatabase::class.java,
                     "RoomTest"
-                ).build()
+                )
+                    .fallbackToDestructiveMigration()
+                    .addCallback(object : Callback() {
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            super.onCreate(db)
+                            Executors.newSingleThreadExecutor().execute {
+                                INSTANCE?.let { roomDb ->
+                                    val dao = roomDb.itemDtoDao()
+                                    chestOnePopulate.forEach { item -> dao.insertItemDto(item) }
+                                    chestTwoPopulate.forEach { item -> dao.insertItemDto(item) }
+                                    chestThreePopulate.forEach { item -> dao.insertItemDto(item) }
+                                }
+                            }
+                        }
+                    })
+                    .build()
                 INSTANCE = instance
                 // return instance
                 instance


### PR DESCRIPTION
Al momento de crearse la base de datos se añaden los items en cada cofre (definido en `ChestPopulate.kt`). Sólo debería ocurrir si abres la app por primera vez, para forzarlo hay que borrar la base de datos de Room, puede hacerse con `context.deleteDatabase("RoomTest")`.